### PR TITLE
Fix empty database password

### DIFF
--- a/oven.php
+++ b/oven.php
@@ -270,7 +270,7 @@ class Oven {
 
         $configPath = $this->installDir . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'app.php';
         foreach (['host', 'username', 'password', 'database'] as $field) {
-            if (isset($_POST[$field]) && !empty($_POST[$field])) {
+            if (isset($_POST[$field])) {
                 $this->_updateDatasourceConfig($configPath, $field, $_POST[$field]);
             }
         }


### PR DESCRIPTION
if the database password is empty string ("") the connection check works, but the final configuration has "sekret" as password and can therefore not connect.